### PR TITLE
feat: adds react and vanilla libraries to path resolution

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -14,7 +14,12 @@
     "noUnusedParameters": false,
     "preserveWatchOutput": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@focuskit/vanilla": ["../vanilla/src/index.ts"],
+      "@focuskit/react": ["../react/src/index.ts"]
+    }
   },
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## New behavior

Follow an approach similar to what is used internally in fluent, one of the typescript configuration base files should include `paths` mapping to all relevant libraries.

This PR adds paths to:

1. `@focuskit/vanilla`
2. `@focuskit/react`
