### PR TITLE
feature: makes HTMLElementWalker filter a private attribute

### DIFF
--- a/packages/vanilla/src/api/Commander.ts
+++ b/packages/vanilla/src/api/Commander.ts
@@ -35,7 +35,7 @@ export class Commander {
     this._messagePipe.use(updateTabIndex);
     this._messagePipe.use(recalcTabIndexes);
 
-    if (this.element.hasAttribute('data-commander')) {
+    if (this.element.hasAttribute("data-commander")) {
       return;
     }
 

--- a/packages/vanilla/src/events/focusFirst.ts
+++ b/packages/vanilla/src/events/focusFirst.ts
@@ -10,8 +10,7 @@ export const focusFirst: FocusKitEventHandler = (event, state, next) => {
   }
 
   const elementWalker = state.elementWalker;
-  elementWalker.filter = tabbable;
 
-  const nextFocused = elementWalker.firstChild();
+  const nextFocused = elementWalker.firstChild(tabbable);
   nextFocused?.focus();
 };

--- a/packages/vanilla/src/events/focusLast.ts
+++ b/packages/vanilla/src/events/focusLast.ts
@@ -13,8 +13,7 @@ export const focusLast: FocusKitEventHandler = (event, state, next) => {
 
   const elementWalker = state.elementWalker;
   elementWalker.currentElement = target;
-  elementWalker.filter = tabbable;
 
-  const nextFocused = elementWalker.lastChild();
+  const nextFocused = elementWalker.lastChild(tabbable);
   nextFocused?.focus();
 };

--- a/packages/vanilla/src/events/moveFirst.ts
+++ b/packages/vanilla/src/events/moveFirst.ts
@@ -18,10 +18,8 @@ export const moveFirst: FocusKitEventHandler = (event, state, next) => {
   }
 
   elementWalker.currentElement = target;
-  const filter = currentEntityFocusable(target);
-  elementWalker.filter = filter;
 
-  const nextFocused = elementWalker.firstChild();
+  const nextFocused = elementWalker.firstChild(currentEntityFocusable(target));
   if (nextFocused) {
     nextFocused.focus();
     makeFocusable(activeElement);

--- a/packages/vanilla/src/events/moveLast.ts
+++ b/packages/vanilla/src/events/moveLast.ts
@@ -19,9 +19,7 @@ export const moveLast: FocusKitEventHandler = (event, state, next) => {
 
   elementWalker.currentElement = target;
   const filter = currentEntityFocusable(target);
-  elementWalker.filter = filter;
-
-  const nextFocused = elementWalker.lastChild();
+  const nextFocused = elementWalker.lastElement(filter);
   if (nextFocused) {
     makeFocusable(activeElement);
     makeTabbable(nextFocused);

--- a/packages/vanilla/src/events/moveNext.ts
+++ b/packages/vanilla/src/events/moveNext.ts
@@ -19,8 +19,10 @@ export const moveNext: FocusKitEventHandler = (event, state, next) => {
 
   elementWalker.currentElement = activeElement;
 
-  elementWalker.filter = currentEntityFocusable(target);
-  const nextFocused = elementWalker.nextElement() ?? elementWalker.firstChild();
+  const elementFilter = currentEntityFocusable(target);
+  const nextFocused =
+    elementWalker.nextElement(elementFilter) ??
+    elementWalker.firstChild(elementFilter);
 
   if (nextFocused) {
     nextFocused.focus();

--- a/packages/vanilla/src/events/movePrev.ts
+++ b/packages/vanilla/src/events/movePrev.ts
@@ -18,10 +18,10 @@ export const movePrev: FocusKitEventHandler = (event, state, next) => {
   }
 
   elementWalker.currentElement = activeElement;
-  const filter = currentEntityFocusable(target);
-  elementWalker.filter = filter;
+  const elementFilter = currentEntityFocusable(target);
   const nextFocused =
-    elementWalker.previousElement() ?? elementWalker.lastChild();
+    elementWalker.previousElement(elementFilter) ??
+    elementWalker.lastElement(elementFilter);
 
   if (nextFocused) {
     nextFocused.focus();

--- a/packages/vanilla/src/events/recalcTabIndexes.ts
+++ b/packages/vanilla/src/events/recalcTabIndexes.ts
@@ -1,4 +1,4 @@
-import { FocusKitEventHandler } from "../types";
+import { FocusKitEventHandler, HTMLElementFilter } from "../types";
 import { hasParentGroup } from "../utils/hasParentGroup";
 import { HTMLElementWalker } from "../utils/HTMLElementWalker";
 import { isFocusable } from "../utils/isFocusable";
@@ -49,7 +49,8 @@ function recalcActiveGroup(
   makeTabbable(target);
   elementWalker.root = target;
   const res: HTMLElement[] = [];
-  elementWalker.filter = (element) => {
+
+  const filter: HTMLElementFilter = (element) => {
     if (element._focuskitFlags) {
       res.push(element);
 
@@ -66,7 +67,7 @@ function recalcActiveGroup(
     return NodeFilter.FILTER_REJECT;
   };
 
-  while (elementWalker.nextElement()) {
+  while (elementWalker.nextElement(filter)) {
     /* noop */
   }
   return res;
@@ -78,7 +79,8 @@ function recalcInActiveGroup(
 ): HTMLElement[] {
   const res: HTMLElement[] = [];
   elementWalker.root = target;
-  elementWalker.filter = (element) => {
+
+  const filter: HTMLElementFilter = (element) => {
     if (element._focuskitFlags) {
       res.push(element);
 
@@ -94,8 +96,7 @@ function recalcInActiveGroup(
     makeFocusable(element);
     return NodeFilter.FILTER_REJECT;
   };
-
-  while (elementWalker.nextElement()) {
+  while (elementWalker.nextElement(filter)) {
     /* noop */
   }
   return res;
@@ -107,7 +108,8 @@ function recalcInActiveCollection(
 ): HTMLElement[] {
   const res: HTMLElement[] = [];
   elementWalker.root = target;
-  elementWalker.filter = (element) => {
+
+  const filter: HTMLElementFilter = (element) => {
     if (!isFocusable(element)) {
       return NodeFilter.FILTER_SKIP;
     }
@@ -119,14 +121,12 @@ function recalcInActiveCollection(
     makeFocusable(element);
     return NodeFilter.FILTER_REJECT;
   };
-
-  while (elementWalker.nextElement()) {
+  while (elementWalker.nextElement(filter)) {
     /* noop */
   }
 
   if (!hasParentGroup(target)) {
-    elementWalker.filter = allFocusable;
-    const firstChild = elementWalker.firstChild();
+    const firstChild = elementWalker.firstChild(allFocusable);
     if (firstChild) {
       makeTabbable(firstChild);
     }
@@ -142,7 +142,8 @@ function recalcActiveCollection(
   const res: HTMLElement[] = [];
   elementWalker.root = target;
   let foundTabbable = false;
-  elementWalker.filter = (element) => {
+
+  const filter: HTMLElementFilter = (element) => {
     if (!isFocusable(element)) {
       return NodeFilter.FILTER_SKIP;
     }
@@ -159,14 +160,12 @@ function recalcActiveCollection(
 
     return NodeFilter.FILTER_REJECT;
   };
-
-  while (elementWalker.nextElement()) {
+  while (elementWalker.nextElement(filter)) {
     /* noop */
   }
 
   if (!foundTabbable) {
-    elementWalker.filter = allFocusable;
-    const firstChild = elementWalker.firstChild();
+    const firstChild = elementWalker.firstChild(allFocusable);
     if (firstChild) {
       makeTabbable(firstChild);
     }

--- a/packages/vanilla/src/utils/HTMLElementWalker.ts
+++ b/packages/vanilla/src/utils/HTMLElementWalker.ts
@@ -1,14 +1,18 @@
 import { HTMLElementFilter } from "../types";
 import { isHTMLElement } from "./isHTMLElement";
 
+function defaultElementFilter() {
+  return NodeFilter.FILTER_ACCEPT;
+}
+
 export class HTMLElementWalker {
-  public filter: HTMLElementFilter;
+  private _elementFilter: HTMLElementFilter;
 
   private _treeWalker: TreeWalker;
   private _root: HTMLElement;
 
-  constructor(root: HTMLElement, elementFilter?: HTMLElementFilter) {
-    this.filter = elementFilter ?? (() => NodeFilter.FILTER_ACCEPT);
+  constructor(root: HTMLElement) {
+    this._elementFilter = defaultElementFilter;
     this._root = root;
 
     this._treeWalker = document.createTreeWalker(
@@ -24,7 +28,7 @@ export class HTMLElementWalker {
             return NodeFilter.FILTER_REJECT;
           }
 
-          return this.filter(node);
+          return this._elementFilter(node);
         },
       }
     );
@@ -39,31 +43,46 @@ export class HTMLElementWalker {
     this._treeWalker.currentNode = this._root;
   }
 
-  firstChild(): HTMLElement | null {
+  firstChild(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
     this._treeWalker.currentNode = this._root;
-    return this._treeWalker.firstChild() as HTMLElement | null;
+    const firstChild = this._treeWalker.firstChild() as HTMLElement | null;
+    this._elementFilter = defaultElementFilter;
+    return firstChild;
   }
 
-  lastChild(): HTMLElement | null {
+  lastChild(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
     this._treeWalker.currentNode = this._root;
     const lastChild = this._treeWalker.lastChild() as HTMLElement | null;
-
-    if (!lastChild) {
-      return null;
-    }
-
-    const nextSibling = this._treeWalker.nextSibling() as HTMLElement | null;
-
-    if (!nextSibling) {
-      return lastChild;
-    } else {
-      this._treeWalker.currentNode = nextSibling;
-      return this.previousElement();
-    }
+    this._elementFilter = defaultElementFilter;
+    return lastChild;
   }
 
-  nextElement(): HTMLElement | null {
+  lastElement(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
+    this._treeWalker.currentNode = this._root;
+    let lastElement: HTMLElement | null = null;
+    let nextElement: HTMLElement | null = null;
+    while ((nextElement = this._treeWalker.lastChild() as HTMLElement | null)) {
+      lastElement = nextElement;
+    }
+    this._elementFilter = defaultElementFilter;
+    return lastElement;
+  }
+
+  nextElement(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
     const nextNode = this._treeWalker.nextNode() as HTMLElement | null;
+    this._elementFilter = defaultElementFilter;
     if (!nextNode || this.isOutsideRoot()) {
       return null;
     }
@@ -71,12 +90,21 @@ export class HTMLElementWalker {
     return nextNode;
   }
 
-  parentElement(): HTMLElement | null {
-    return this._treeWalker.parentNode() as HTMLElement | null;
+  parentElement(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
+    const parentElement = this._treeWalker.parentNode() as HTMLElement | null;
+    this._elementFilter = defaultElementFilter;
+    return parentElement;
   }
 
-  previousElement(): HTMLElement | null {
+  previousElement(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
     const previousNode = this._treeWalker.previousNode() as HTMLElement | null;
+    this._elementFilter = defaultElementFilter;
     if (!previousNode || this.isOutsideRoot()) {
       return null;
     }
@@ -84,8 +112,12 @@ export class HTMLElementWalker {
     return previousNode;
   }
 
-  nextSibling(): HTMLElement | null {
+  nextSibling(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
     const nextSibling = this._treeWalker.nextSibling() as HTMLElement | null;
+    this._elementFilter = defaultElementFilter;
     if (!nextSibling || this.isOutsideRoot()) {
       return null;
     }
@@ -93,9 +125,13 @@ export class HTMLElementWalker {
     return nextSibling;
   }
 
-  previousSibling(): HTMLElement | null {
+  previousSibling(
+    elementFilter: HTMLElementFilter = defaultElementFilter
+  ): HTMLElement | null {
+    this._elementFilter = elementFilter;
     const previousSibling =
       this._treeWalker.previousSibling() as HTMLElement | null;
+    this._elementFilter = defaultElementFilter;
     if (!previousSibling || this.isOutsideRoot()) {
       return null;
     }

--- a/packages/vanilla/src/utils/ariaHideOthers.ts
+++ b/packages/vanilla/src/utils/ariaHideOthers.ts
@@ -7,17 +7,18 @@ export function ariaHideOthers(...visible: HTMLElement[]) {
 
   const hidden: HTMLElement[] = [];
   const elementWalker = new HTMLElementWalker(visible[0].ownerDocument.body);
-  elementWalker.filter = (element) => {
-    if (visible.every((visibleEl) => !element.contains(visibleEl))) {
-      element.setAttribute("aria-hidden", "true");
-      hidden.push(element);
-      return NodeFilter.FILTER_REJECT;
-    }
 
-    return NodeFilter.FILTER_SKIP;
-  };
+  while (
+    elementWalker.nextElement((element) => {
+      if (visible.every((visibleEl) => !element.contains(visibleEl))) {
+        element.setAttribute("aria-hidden", "true");
+        hidden.push(element);
+        return NodeFilter.FILTER_REJECT;
+      }
 
-  while (elementWalker.nextElement()) {
+      return NodeFilter.FILTER_SKIP;
+    })
+  ) {
     /* noop */
   }
 

--- a/packages/vanilla/src/utils/focusFinders.ts
+++ b/packages/vanilla/src/utils/focusFinders.ts
@@ -5,8 +5,7 @@ const elementWalker = new HTMLElementWalker(document.body);
 
 export function findFirstFocusable(container: HTMLElement) {
   elementWalker.root = container;
-  elementWalker.filter = allFocusable;
-  return elementWalker.firstChild();
+  return elementWalker.firstChild(allFocusable);
 }
 
 export function findPrevFocusable(
@@ -15,8 +14,7 @@ export function findPrevFocusable(
 ) {
   elementWalker.root = container;
   elementWalker.currentElement = current;
-  elementWalker.filter = allFocusable;
-  return elementWalker.previousElement();
+  return elementWalker.previousElement(allFocusable);
 }
 
 export function findNextFocusable(
@@ -25,14 +23,12 @@ export function findNextFocusable(
 ) {
   elementWalker.root = container;
   elementWalker.currentElement = current;
-  elementWalker.filter = allFocusable;
-  return elementWalker.nextElement();
+  return elementWalker.nextElement(allFocusable);
 }
 
 export function findLastFocusable(container: HTMLElement) {
   elementWalker.root = container;
-  elementWalker.filter = allFocusable;
-  return elementWalker.lastChild();
+  return elementWalker.lastChild(allFocusable);
 }
 
 export function findAllFocusable(
@@ -41,13 +37,12 @@ export function findAllFocusable(
 ) {
   const focusable: HTMLElement[] = [];
   elementWalker.root = container;
-  elementWalker.filter = allFocusable;
-  let cur = elementWalker.nextElement();
+  let cur = elementWalker.nextElement(allFocusable);
   while (cur) {
     if (filter(cur)) {
       focusable.push(cur);
     }
-    cur = elementWalker.nextElement();
+    cur = elementWalker.nextElement(allFocusable);
   }
 
   return focusable;
@@ -55,12 +50,10 @@ export function findAllFocusable(
 
 export function findFirstTabbable(container: HTMLElement) {
   elementWalker.root = container;
-  elementWalker.filter = tabbable;
-  return elementWalker.firstChild();
+  return elementWalker.firstChild(tabbable);
 }
 
 export function findLastTabbable(container: HTMLElement) {
   elementWalker.root = container;
-  elementWalker.filter = tabbable;
-  return elementWalker.lastChild();
+  return elementWalker.lastChild(tabbable);
 }


### PR DESCRIPTION
## New Behaviours

1. makes `HTMLElementWalker` filter a private method
2. filters now can be provided per invocation of a walking method (e,g: `walker.nextChild(filter)`)
3. Fix navigation to support deep elements (tree scenario)